### PR TITLE
Revert "Revert "Spec: for SUSE add explicit deps for pkgconfig (#28)""

### DIFF
--- a/src/Commands/Spec.hs
+++ b/src/Commands/Spec.hs
@@ -253,7 +253,7 @@ createSpecFile pkgdata flags mdest = do
     putHdr "Requires" $ (if binlib then "ghc-%{name}" else "%{name}") ++ isa +-+ "= %{version}-%{release}"
     unless (null $ clibs ++ pkgcfgs) $ do
       put "# Begin cabal-rpm deps:"
-      mapM_ (putHdr "Requires") $ sort $ map (++ isa) clibs ++ pkgcfgs
+      mapM_ (putHdr "Requires") $ sort $ map (++ isa) clibs ++ pkgcfgs ++ ["pkgconfig" | distro == SUSE, not $ null pkgcfgs]
       put "# End cabal-rpm deps"
     putNewline
     put $ "%description" +-+ ghcPkgDevel


### PR DESCRIPTION
This undoes the revert from 6ef65863a4. We *do* need the pkgconfig
listed as an explicit dependency, because that package is not included
in our JeOS base image; so it needs to be listed explicitly to be
available.

We could, in theory, add logic to rpm-macros that infers an

  BuildRequires: pkgconfig

attribute when it sees a

  BuildRequires: pkgconfig(foo)

attribute included in the spec file, but that logic would have to go
into the main rpm-macros package, not into the GHC specific one, so it's
a rather big change to make.