### PR TITLE
Add --strict flag to make cabal-rpm fail rather than generate an invalid spec file.

### DIFF
--- a/src/Commands/Depends.hs
+++ b/src/Commands/Depends.hs
@@ -39,7 +39,7 @@ depends pkgdata action = do
       let pkgcfgs' = map (++ ".pc") pkgcfgs
       mapM_ putStrLn $ deps ++ tools ++ clibs' ++ pkgcfgs'
     Requires -> do
-      (deps, tools, clibs, pkgcfgs, _) <- packageDependencies pkgDesc
+      (deps, tools, clibs, pkgcfgs, _) <- packageDependencies False pkgDesc
       mapM_ putStrLn $ sort $ deps ++ tools ++ clibs ++ pkgcfgs
     Missing -> do
       miss <- missingPackages pkgDesc >>= filterM notAvail

--- a/src/Commands/Spec.hs
+++ b/src/Commands/Spec.hs
@@ -93,7 +93,7 @@ createSpecFile pkgdata flags mdest = do
       hasExecPkg = binlib || (hasExec && not hasLib)
   -- run commands before opening file to prevent empty file on error
   -- maybe shell commands should be in a monad or something
-  (deps, tools, clibs, pkgcfgs, selfdep) <- packageDependencies pkgDesc
+  (deps, tools, clibs, pkgcfgs, selfdep) <- packageDependencies (rpmStrict flags) pkgDesc
   let testsuiteDeps = testsuiteDependencies pkgDesc name
   missTestDeps <- filterM notInstalled testsuiteDeps
 

--- a/src/Setup.hs
+++ b/src/Setup.hs
@@ -48,6 +48,7 @@ data RpmFlags = RpmFlags
     , rpmForce               :: Bool
     , rpmHelp                :: Bool
     , rpmBinary              :: Bool
+    , rpmStrict              :: Bool
     , rpmRelease             :: Maybe String
     , rpmCompilerId          :: Maybe CompilerId
     , rpmDistribution        :: Maybe Distro
@@ -62,6 +63,7 @@ emptyRpmFlags = RpmFlags
     , rpmForce = False
     , rpmHelp = False
     , rpmBinary = False
+    , rpmStrict = False
     , rpmRelease = Nothing
     , rpmCompilerId = Nothing
     , rpmDistribution = Nothing
@@ -83,6 +85,8 @@ options =
              "Set given flags in Cabal conditionals",
       Option "" ["force"] (NoArg (\x -> x { rpmForce = True }))
              "Overwrite existing spec file.",
+      Option "" ["strict"] (NoArg (\x -> x { rpmStrict = True }))
+             "Fail rather than produce an incomplete spec file.",
       Option "" ["release"] (ReqArg (\rel x -> x { rpmRelease = Just rel }) "RELEASE")
              "Override the default package release",
       Option "" ["compiler"] (ReqArg (\cid x -> x { rpmCompilerId = Just (parseCompilerId cid) }) "COMPILER-ID")


### PR DESCRIPTION
When cabal-rpm cannot resolve which package provides a required library file,
it used to simply omit the dependency from the generated output. The new
`--strict` flag makes the tool fail with an run-time error instead. This is
useful for people who run cabal-rpm in some kind of batch environment (i.e.
using a makefile) and who want to make sure no errors are missed.

Cc: @mimi1vx 