### PR TITLE
If a library does not expose any modules, do not run haddock.

### DIFF
--- a/src/Commands/Spec.hs
+++ b/src/Commands/Spec.hs
@@ -317,7 +317,9 @@ createSpecFile pkgdata flags mdest = do
     let cabalFlags = [ "-f" ++ (if b then "" else "-") ++ n | (FlagName n, b) <- rpmConfigurationsFlags flags ]
     put $ "%define cabal_configure_options " ++ unwords cabalFlags
   let pkgType = if hasLib then "lib" else "bin"
-  put $ "%ghc_" ++ pkgType ++ "_build"
+  case (pkgType, exposesModules) of
+    ("lib", False) -> put $ "%ghc_" ++ pkgType ++ "_build_without_haddock"
+    _ -> put $ "%ghc_" ++ pkgType ++ "_build"
   sectionNewline
 
   put "%install"


### PR DESCRIPTION
This comes up with the nats package.  This package has been merged into
base, but some things still require it via cabal.  If nats detects it is
building on a system where it is already a part of base, it will expose
no modules and attempting to run cabal-rpm will fail when it gets to
running haddock.

The fix is to make sure %ghc_lib_build_without_haddock is emitted in
this case.